### PR TITLE
menuHoverShow : personnalisation de la taille et de l'espacement des icones du menu sans changer de code

### DIFF
--- a/menuHoverShow/css/perso.css
+++ b/menuHoverShow/css/perso.css
@@ -1,7 +1,9 @@
 :root {
   --menu-width:250px;
   --menu-text-width:190px;
-  --logo-width: 60px;
+  --logo-width:60px;
+  --logo-height:36px;
+  --logo-size:20px;
   --menu-background-color: #212121;
   --design-background-color: #e2e2e2;
 
@@ -11,17 +13,19 @@
   --button-bottom-hovercolor: #555555;
 }
 
+
 .fa-2x {
 	font-size: 2em;
 }
+
 .fa {
 	position: relative;
 	display: table-cell;
 	width: var(--logo-width);
-	height: 36px;
+	height: var(--logo-height);
 	text-align: center;
 	vertical-align: middle;
-	font-size:20px;
+	font-size: var(--logo-size);
 }
 
 
@@ -82,7 +86,7 @@
 	position:relative;
 	display:table-cell;
 	width:var(--logo-width);
-	height:36px;
+	height:var(--logo-height);
 	text-align:center;
 	vertical-align:middle;
 	font-size:18px;

--- a/menuHoverShow/index.html
+++ b/menuHoverShow/index.html
@@ -92,6 +92,8 @@ Liste des icônes font-awesome pour l'affichage des boutons :
 				// get perso.json parameters
 				let menu_width = data.parameters.menu_width?data.parameters.menu_width:"250px";
 				let logo_width = data.parameters.logo_width?data.parameters.logo_width:"60px";
+				let logo_height = data.parameters.logo_height?data.parameters.logo_height:"36px"; 
+ 				let logo_size = data.parameters.logo_size?data.parameters.logo_size:"20px";              
 				let menu_text_width = parseInt(menu_width.split('px').join('')) - parseInt(logo_width.split('px').join('')) + 'px';
 				let button_head_color = data.parameters.button_head_color?data.parameters.button_head_color:"#428bca";
 				let button_bottom_color = data.parameters.button_bottom_color?data.parameters.button_bottom_color:"#999999";
@@ -104,6 +106,8 @@ Liste des icônes font-awesome pour l'affichage des boutons :
 				// menu size
 				document.documentElement.style.setProperty('--menu-width', menu_width);
 				document.documentElement.style.setProperty('--logo-width', logo_width);
+              			document.documentElement.style.setProperty('--logo-height', logo_height);
+              			document.documentElement.style.setProperty('--logo-size', logo_size);              
 				document.documentElement.style.setProperty('--menu-text-width', menu_text_width);
 				// buttons colors
 				document.documentElement.style.setProperty('--button-head-color', button_head_color);

--- a/menuHoverShow/json/perso.json
+++ b/menuHoverShow/json/perso.json
@@ -29,21 +29,22 @@
 			"label": "Paramétrage",
 			"link": "9",
 			"icon": "fa fa-2x fa-sitemap"
-		}, {
-            "link": "2",
-            "icon": "fa fa-power-off fa-2x",
+		},{
+        		"link": "2",
+            		"icon": "fa fa-power-off fa-2x",
 			"label": "Se déconnecter"
-        }
+        	}
 	],
 	"parameters": {
       	"menu_width": "250px",
       	"logo_width": "60px",
-      	"menu_background_color": "#212121",
-      	"design_background_color": "#e2e2e2",
-
-		"button_head_color": "#428bca",
-		"button_bottom_color": "#999999",
-		"button_head_hovercolor": "#5fa2db",
-		"button_bottom_hovercolor": "#555555"
+        "logo_height": "36px",
+        "logo_size": "20px",      
+      	"menu_background_color": "#505050",
+      	"design_background_color": "#505050",
+	"button_head_color": "#428bca",
+	"button_bottom_color": "#999999",
+	"button_head_hovercolor": "#5fa2db",
+	"button_bottom_hovercolor": "#555555"
 	}
 }


### PR DESCRIPTION
adaptation des fichiers index.html, perso.css et et perso.json pour permettre la personnalisation de la taille et de l'espacement des icones du menu sans changer le code, tout se fait via paramétrisation du fichier perso.json.

creation et utilisation de deux nouvelles variables :   
--logo-height:36px;
--logo-size:20px;

fonctionne bien chez moi, icones plus grandes et plus lisibles,  avec , dans perso.json
        "logo_height": "50px",
      	"logo_size": "34px",